### PR TITLE
expanding chat command functionality

### DIFF
--- a/packages/backend/src/bot-engine/engine.ts
+++ b/packages/backend/src/bot-engine/engine.ts
@@ -70,7 +70,7 @@ function normalizeFlowData(raw: any): FlowDefinition {
       const cmd = config.command || '';
       const prefix = cmd.startsWith('!') ? '!' : config.commandPrefix || '!';
       const name = cmd.startsWith('!') ? cmd.substring(1) : cmd;
-      data = { triggerType: 'command', label, commandPrefix: prefix, commandName: name };
+      data = { triggerType: 'command', label, commandPrefix: prefix, commandName: name, channelId: config.channelId ? String(config.channelId) : undefined, };
     } else if (nodeType === 'action_kick') {
       type = 'action';
       data = { actionType: 'kick', label, reasonId: parseInt(config.reasonid) || 5, reasonMsg: config.reason || '' };
@@ -348,6 +348,8 @@ export class BotEngine {
         } else {
           console.log(`[BotEngine] SSH already connected for ${dbFlow.serverConfigId}:${dbFlow.virtualServerId}`);
         }
+        // NEW: start/stop per-channel command listeners for this pair
+        this.syncCommandListenersForPair(dbFlow.serverConfigId, dbFlow.virtualServerId);
       }
 
       // Setup cron jobs for this flow
@@ -493,19 +495,43 @@ export class BotEngine {
       this.eventBridge.connectServer(configId, sid).catch(err => {
         console.error(`[BotEngine] SSH connection failed for ${pair}: ${err.message}`);
       });
+      this.syncCommandListenersForPair(configId, sid);
     }
   }
 
   private async cleanupUnusedSshConnections(): Promise<void> {
-    const neededKeys = new Set<string>();
+    const neededPairs = new Set<string>();
     for (const flow of this.flows.values()) {
-      neededKeys.add(`${flow.serverConfigId}:${flow.virtualServerId}`);
+      neededPairs.add(`${flow.serverConfigId}:${flow.virtualServerId}`);
     }
 
+    // 1) Base SSH connections entfernen, die niemand mehr braucht
     for (const key of this.eventBridge.getConnectedKeys()) {
-      if (!neededKeys.has(key)) {
+      if (!neededPairs.has(key)) {
         const [configId, sid] = key.split(':').map(Number);
         await this.eventBridge.disconnectServer(configId, sid);
+      }
+    }
+
+    // 2) Command listeners pro *benötigtem* pair syncen
+    for (const pair of neededPairs) {
+      const [configId, sid] = pair.split(':').map(Number);
+      this.syncCommandListenersForPair(configId, sid);
+    }
+
+    // 3) Command listeners für Pairs entfernen, die komplett weg sind
+    for (const cmdKey of this.eventBridge.getCommandListenerKeys()) {
+      // expected: `${configId}:${sid}:cmd:${channelId}`
+      const m = cmdKey.match(/^(\d+):(\d+):cmd:(\d+)$/);
+      if (!m) continue;
+
+      const configId = Number(m[1]);
+      const sid = Number(m[2]);
+      const channelId = Number(m[3]);
+
+      const pairKey = `${configId}:${sid}`;
+      if (!neededPairs.has(pairKey)) {
+        await this.eventBridge.disconnectCommandListener(configId, sid, channelId);
       }
     }
   }
@@ -540,22 +566,93 @@ export class BotEngine {
         // Command trigger (special case of text message)
         if (triggerData.triggerType === 'command' && eventName === 'notifytextmessage') {
           const cmdTrigger = triggerData as CommandTriggerData;
+
+          // Backward-compat:
+          // - if trigger has NO channelId => only react to base connection events
+          // - if trigger HAS channelId => only react if event came from that cmd listener OR matches target
+          const sourceListenerCid = data.__cmd_listener_channel_id;
+
+          if (!cmdTrigger.channelId) {
+            if (sourceListenerCid) continue;
+          } else {
+            const required = String(cmdTrigger.channelId);
+
+            // For channel-specific commands: only accept events coming from the dedicated cmd listener
+            if (!sourceListenerCid) continue;
+            if (sourceListenerCid !== required) continue;
+          }
+
           const msg = data.msg || '';
           const fullCommand = (cmdTrigger.commandPrefix || '!') + cmdTrigger.commandName;
-
           if (!msg.startsWith(fullCommand)) continue;
 
-          // Check that the command is followed by a space or is the entire message
           const afterCmd = msg.substring(fullCommand.length);
           if (afterCmd.length > 0 && afterCmd[0] !== ' ') continue;
 
           const args = afterCmd.trim();
-          const enrichedData = { ...data, command_args: args, command_name: cmdTrigger.commandName };
+          const enrichedData = {
+            ...data,
+            command_args: args,
+            command_name: cmdTrigger.commandName,
+            command_channel_id: data.__cmd_listener_channel_id || cmdTrigger.channelId || data.target || '',
+          };
+
+          const invoker =
+            data.clid ||
+            data.invokerid ||
+            data.invoker_id ||
+            data.invokerId ||
+            data.client_id ||
+            data.clientId;
+
+          if (invoker && !data.clid) {
+            // sorgt dafür, dass {{event.clid}} und executeMove() funktionieren
+            (enrichedData as any).clid = String(invoker);
+          }
+
           this.executeFlow(flow, triggerNode.id, 'command', enrichedData);
         }
       }
     }
   }
+
+
+  private getNeededCommandChannelIds(configId: number, sid: number): number[] {
+    const ids = new Set<number>();
+
+    for (const flow of this.flows.values()) {
+      if (flow.serverConfigId !== configId || flow.virtualServerId !== sid) continue;
+
+      for (const t of flow.triggerNodes) {
+        const td: any = t.data;
+        if (td?.triggerType === 'command' && td.channelId) {
+          const n = parseInt(String(td.channelId), 10);
+          if (Number.isFinite(n) && n > 0) ids.add(n);
+        }
+      }
+    }
+    return Array.from(ids);
+  }
+
+  private syncCommandListenersForPair(configId: number, sid: number): void {
+    const needed = new Set(this.getNeededCommandChannelIds(configId, sid));
+    const existing = new Set(this.eventBridge.getCommandListenerChannelIds(configId, sid));
+
+    for (const cid of needed) {
+      if (!existing.has(cid)) {
+        this.eventBridge.connectCommandListener(configId, sid, cid).catch(err => {
+          console.error(`[BotEngine] CMD listener connect failed for ${configId}:${sid}:${cid}: ${err.message}`);
+        });
+      }
+    }
+
+    for (const cid of existing) {
+      if (!needed.has(cid)) {
+        this.eventBridge.disconnectCommandListener(configId, sid, cid).catch(() => { });
+      }
+    }
+  }
+
 
   private executeFlow(flow: LoadedFlow, triggerNodeId: string, triggerType: string, eventData: Record<string, string>): void {
     console.log(`[BotEngine] Executing flow ${flow.id} ('${flow.name}') triggered by ${triggerType}`);

--- a/packages/backend/src/bot-engine/event-bridge.ts
+++ b/packages/backend/src/bot-engine/event-bridge.ts
@@ -126,11 +126,86 @@ export class EventBridge extends EventEmitter {
     return Array.from(this.connections.keys());
   }
 
+  private commandListeners: Map<string, SshQueryClient> = new Map();
+
+  private makeCmdKey(configId: number, sid: number, channelId: number): string {
+    return `${configId}:${sid}:cmd:${channelId}`;
+  }
+
+  async connectCommandListener(configId: number, sid: number, channelId: number): Promise<void> {
+    const key = this.makeCmdKey(configId, sid, channelId);
+    if (this.commandListeners.has(key)) return;
+
+    const serverConfig = await this.prisma.tsServerConfig.findUnique({ where: { id: configId } });
+    if (!serverConfig?.sshUsername || !serverConfig.sshPassword || !serverConfig.sshPort) return;
+
+    const client = new SshQueryClient({
+      host: serverConfig.host,
+      port: serverConfig.sshPort,
+      username: serverConfig.sshUsername,
+      password: decrypt(serverConfig.sshPassword),
+    });
+
+    client.on('ready', async () => {
+      console.log(`[EventBridge] CMD listener SSH connected for ${key}`);
+      try {
+        await client.registerCommandListener(sid, channelId);
+      } catch (err: any) {
+        console.error(`[EventBridge] CMD listener register failed for ${key}: ${err.message}`);
+      }
+    });
+
+    client.on('event', (eventName: string, data: Record<string, string>) => {
+      // Marker so engine can keep backward compatibility:
+      // triggers WITHOUT channelId should only react to base connection events
+      const enriched = { ...data, __cmd_listener_channel_id: String(channelId) };
+      this.emit('tsEvent', configId, sid, eventName, enriched);
+    });
+
+    client.on('error', (err: Error) => console.error(`[EventBridge] CMD listener SSH error for ${key}: ${err.message}`));
+    client.on('close', () => console.log(`[EventBridge] CMD listener SSH disconnected for ${key}`));
+
+    this.commandListeners.set(key, client);
+    try { await client.connect(); } catch (err: any) {
+      console.error(`[EventBridge] CMD listener initial connect failed for ${key}: ${err.message}`);
+      if (client.hasFatalError) this.commandListeners.delete(key);
+    }
+  }
+
+  async disconnectCommandListener(configId: number, sid: number, channelId: number): Promise<void> {
+    const key = this.makeCmdKey(configId, sid, channelId);
+    const client = this.commandListeners.get(key);
+    if (client) {
+      client.destroy();
+      this.commandListeners.delete(key);
+    }
+  }
+
+  getCommandListenerChannelIds(configId: number, sid: number): number[] {
+    const prefix = `${configId}:${sid}:cmd:`;
+    return Array.from(this.commandListeners.keys())
+      .filter(k => k.startsWith(prefix))
+      .map(k => parseInt(k.split(':').pop() || '0', 10))
+      .filter(n => Number.isFinite(n) && n > 0);
+  }
+
+  getCommandListenerKeys(): string[] {
+    return Array.from(this.commandListeners.keys());
+  }
+
   destroy(): void {
-    for (const [key, client] of this.connections.entries()) {
+  // existing "base" SSH connections
+    for (const client of this.connections.values()) {
       client.destroy();
     }
     this.connections.clear();
+
+    // NEW: command listener SSH connections
+    for (const client of this.commandListeners.values()) {
+      client.destroy();
+    }
+    this.commandListeners.clear();
+
     this.removeAllListeners();
   }
 }

--- a/packages/backend/src/bot-engine/ssh-query-client.ts
+++ b/packages/backend/src/bot-engine/ssh-query-client.ts
@@ -2,6 +2,7 @@ import { Client as SSH2Client, type ClientChannel } from 'ssh2';
 import { EventEmitter } from 'events';
 import { parseQueryResponse } from '@ts6/common';
 import { TS_EVENT_TYPES } from '@ts6/common';
+import crypto from 'crypto';
 
 export interface SshQueryClientOptions {
   host: string;
@@ -42,6 +43,7 @@ export class SshQueryClient extends EventEmitter {
   private reconnectTimer: ReturnType<typeof setTimeout> | null = null;
   private keepaliveTimer: ReturnType<typeof setInterval> | null = null;
   private fatalError: boolean = false;
+  private readonly nickSuffix = crypto.randomBytes(3).toString('hex'); // z.B. "a1b2c3"
 
   constructor(private options: SshQueryClientOptions) {
     super();
@@ -62,7 +64,7 @@ export class SshQueryClient extends EventEmitter {
           console.error(`[SshQueryClient] ${err.message}`);
           this.emit('error', err);
           reject(err);
-          try { this.ssh?.end(); } catch {}
+          try { this.ssh?.end(); } catch { }
         }
       }, 15000);
 
@@ -181,10 +183,8 @@ export class SshQueryClient extends EventEmitter {
 
     // Set nickname so the bot is identifiable, and mark as query client type
     try {
-      await this.executeCommand('clientupdate client_nickname=TS6-WebUI-Bot');
-    } catch {
-      // Nickname might already be taken; not critical
-    }
+      await this.executeCommand(`clientupdate client_nickname=TS6-WebUI-Bot-${sid}-${this.nickSuffix}`);
+    } catch { }
 
     for (const eventType of TS_EVENT_TYPES) {
       const cmd = eventType === 'channel'
@@ -201,6 +201,59 @@ export class SshQueryClient extends EventEmitter {
     }
 
     console.log(`[SshQueryClient] Events registered for sid=${sid}`);
+  }
+
+  async registerCommandListener(sid: number, channelId: number): Promise<void> {
+    console.log(`[SshQueryClient] Registering command listener for sid=${sid}, channelId=${channelId} on ${this.options.host}`);
+
+    await this.executeCommand(`use sid=${sid}`);
+
+    // Optional: identifiable nickname
+    try {
+      await this.executeCommand(`clientupdate client_nickname=TS6-WebUI-Cmd-${channelId}-${this.nickSuffix}`);
+    } catch (err: any) {
+      if (String(err.message || '').toLowerCase().includes('nickname')) {
+        const extra = crypto.randomBytes(2).toString('hex');
+        try {
+          await this.executeCommand(`clientupdate client_nickname=TS6-WebUI-Cmd-${channelId}-${this.nickSuffix}-${extra}`);
+        } catch { }
+      }
+    }
+
+    // Move query client into the channel (required for channel chat notifications)
+    try {
+      const who = await this.executeCommand('whoami');
+      const first = (who.split('\n')[0] || '').trim();
+      const me = parseQueryResponse(first)[0] || {};
+      const clid =
+        me.clid ??
+        me.client_id ??
+        me.clientid ??
+        me.clientId ??
+        (() => {
+          const m = first.match(/(?:clid|client_id)=(\d+)/);
+          return m?.[1];
+        })();
+
+      if (clid) {
+        await this.executeCommand(`clientmove clid=${clid} cid=${channelId}`);
+      } else {
+        console.warn('[SshQueryClient] whoami did not return clid; cannot clientmove');
+      }
+    } catch (err: any) {
+      console.warn(`[SshQueryClient] Failed to move query client to channel ${channelId}: ${err.message}`);
+    }
+
+    // Register ONLY textchannel for this channel
+    try {
+      await this.executeCommand(`servernotifyregister event=textchannel id=${channelId}`);
+    } catch (err: any) {
+      if (!err.message?.includes('516')) {
+        console.warn(`[SshQueryClient] Failed to register textchannel for channel ${channelId}: ${err.message}`);
+      }
+    }
+
+    console.log(`[SshQueryClient] Command listener ready for sid=${sid}, channelId=${channelId}`);
   }
 
   get isConnected(): boolean {

--- a/packages/common/src/types/bot.ts
+++ b/packages/common/src/types/bot.ts
@@ -59,6 +59,7 @@ export interface CommandTriggerData {
   commandPrefix: string;
   commandName: string;
   description?: string;
+  channelId?: string;
 }
 
 // --- Action Types ---

--- a/packages/frontend/src/pages/BotEditor.tsx
+++ b/packages/frontend/src/pages/BotEditor.tsx
@@ -19,6 +19,7 @@ import {
 import { toast } from 'sonner';
 import { cn } from '@/lib/utils';
 import { PlaceholderReference } from '@/components/bots/PlaceholderReference';
+import { Textarea } from '@/components/ui/textarea';
 
 // --- Node type definitions ---
 type HandleConfig = {
@@ -737,14 +738,46 @@ export default function BotEditor() {
                   )}
 
                   {selectedNodeData.type === 'trigger_command' && (
-                    <div>
-                      <Label className="text-[10px] text-muted-foreground">Command Prefix</Label>
-                      <Input
-                        className="h-7 text-xs mt-1 font-mono-data"
-                        placeholder="!help"
-                        value={selectedNodeData.config.command || ''}
-                        onChange={(e) => setNodes((prev) => prev.map((n) => n.id === selectedNode ? { ...n, config: { ...n.config, command: e.target.value } } : n))}
-                      />
+                  <div className="space-y-2">
+                      <div>
+                        <Label className="text-[10px] text-muted-foreground">Command</Label>
+                        <Input
+                          className="h-7 text-xs mt-1 font-mono-data"
+                          placeholder="!help"
+                          value={selectedNodeData.config.command || ''}
+                          onChange={(e) =>
+                            setNodes((prev) =>
+                              prev.map((n) =>
+                                n.id === selectedNode
+                                  ? { ...n, config: { ...n.config, command: e.target.value } }
+                                  : n
+                              )
+                            )
+                          }
+                        />
+                      </div>
+
+                      <div>
+                        <Label className="text-[10px] text-muted-foreground">Listen Channel ID (optional)</Label>
+                        <Input
+                          type="number"
+                          className="h-7 text-xs mt-1 font-mono-data"
+                          placeholder="42"
+                          value={selectedNodeData.config.channelId || ''}
+                          onChange={(e) =>
+                            setNodes((prev) =>
+                              prev.map((n) =>
+                                n.id === selectedNode
+                                  ? { ...n, config: { ...n.config, channelId: e.target.value } }
+                                  : n
+                              )
+                            )
+                          }
+                        />
+                        <p className="text-[9px] text-muted-foreground/60 mt-0.5">
+                          Commands are only received while a ServerQuery client is in that channel.
+                        </p>
+                      </div>
                     </div>
                   )}
 
@@ -779,12 +812,23 @@ export default function BotEditor() {
                       )}
                       <div>
                         <Label className="text-[10px] text-muted-foreground">Message</Label>
-                        <Input
-                          className="h-7 text-xs mt-1"
-                          placeholder="Hello {{event.client_nickname}}"
+                        <Textarea
+                          className="min-h-[120px] text-xs mt-1 resize-y font-mono-data"
+                          placeholder={"Dies ist die HelpList:\n\n!create - erstellt einen Channel\n!delete - löscht deinen Channel\n!help - zeigt diese Liste"}
                           value={selectedNodeData.config.message || ''}
-                          onChange={(e) => setNodes((prev) => prev.map((n) => n.id === selectedNode ? { ...n, config: { ...n.config, message: e.target.value } } : n))}
+                          onChange={(e) =>
+                            setNodes((prev) =>
+                              prev.map((n) =>
+                                n.id === selectedNode
+                                  ? { ...n, config: { ...n.config, message: e.target.value } }
+                                  : n
+                              )
+                            )
+                          }
                         />
+                        <p className="text-[9px] text-muted-foreground/60 mt-0.5">
+                          Tipp: Zeilenumbrüche werden übernommen.
+                        </p>
                       </div>
                     </div>
                   )}
@@ -826,8 +870,24 @@ export default function BotEditor() {
 
                   {selectedNodeData.type === 'action_move' && (
                     <div>
-                      <Label className="text-[10px] text-muted-foreground">Target Channel ID</Label>
-                      <Input type="number" className="h-7 text-xs mt-1 font-mono-data" placeholder="1" value={selectedNodeData.config.cid || ''} onChange={(e) => setNodes((prev) => prev.map((n) => n.id === selectedNode ? { ...n, config: { ...n.config, cid: parseInt(e.target.value) || 0 } } : n))} />
+                      <Label className="text-[10px] text-muted-foreground">Target Channel ID (or template)</Label>
+                      <Input
+                        className="h-7 text-xs mt-1 font-mono-data"
+                        placeholder="94  or  {{temp.lastCreatedChannelId}}"
+                        value={selectedNodeData.config.cid ?? ''}
+                        onChange={(e) =>
+                          setNodes((prev) =>
+                            prev.map((n) =>
+                              n.id === selectedNode
+                                ? { ...n, config: { ...n.config, cid: e.target.value } }
+                                : n
+                            )
+                          )
+                        }
+                      />
+                      <p className="text-[9px] text-muted-foreground/60 mt-0.5">
+                        Example: 94 or {"{{temp.lastCreatedChannelId}}"}
+                      </p>
                     </div>
                   )}
 


### PR DESCRIPTION
- added optional field for listener channel in chat command node
- event listener for each channel seperate with separate ssh client that gets moved into the channel to listen (when client already in channel - only eventregister - so no "client flooding")

- fixed client move node so numbers OR variables can be used

- fixed temp.lastCreatedChannelId when even.clid is empty (so moving works everytime if needed)

- message node now able to set (kind of) preformatted messages.